### PR TITLE
Invert icons used for import / export

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -52,7 +52,7 @@ function CustomToolbar({openDialog}) {
                     <GridToolbarDensitySelector/>
                 </Grid>
                 <Grid item>
-                    <Button variant="contained" onClick={openDialog} endIcon={<UploadIcon/>}>Import into new
+                    <Button variant="contained" onClick={openDialog} endIcon={<DownloadIcon/>}>Import into new
                         volume</Button>
                 </Grid>
             </Grid>
@@ -175,7 +175,7 @@ export function App() {
                         key={"action_export_" + params.row.id}
                         icon={
                             <Tooltip title="Export volume">
-                                <DownloadIcon>Export volume</DownloadIcon>
+                                <UploadIcon>Export volume</UploadIcon>
                             </Tooltip>
                         }
                         label="Export volume"
@@ -186,7 +186,7 @@ export function App() {
                         key={"action_import_" + params.row.id}
                         icon={
                             <Tooltip title="Import">
-                                <UploadIcon>Import</UploadIcon>
+                                <DownloadIcon>Import</DownloadIcon>
                             </Tooltip>
                         }
                         label="Import"


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

Just use the download icon for import, and upload icon for exporting, that seems more intuitive as a developer

<img width="1455" alt="Screenshot 2022-08-26 at 15 59 17" src="https://user-images.githubusercontent.com/437958/186920680-d7fab69d-a07b-40a8-87dd-ee4e9263bf90.png">
