### PR TITLE
Do not keep docker engine CLI in memory, re-instantiate if for every HTTP request

### DIFF
--- a/vm/go.mod
+++ b/vm/go.mod
@@ -1,4 +1,4 @@
-module github.com/felipecruz91/vackup-docker-extension
+module github.com/docker/volumes-backup-extension
 
 go 1.17
 

--- a/vm/internal/backend/containers.go
+++ b/vm/internal/backend/containers.go
@@ -2,18 +2,19 @@ package backend
 
 import (
 	"context"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/client"
-	"github.com/felipecruz91/vackup-docker-extension/internal"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
-	"golang.org/x/sync/errgroup"
 	"io"
 	"os"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/docker/volumes-backup-extension/internal"
+	"github.com/docker/volumes-backup-extension/internal/log"
+	"golang.org/x/sync/errgroup"
 )
 
 func GetContainersForVolume(ctx context.Context, cli *client.Client, volumeName string) []string {

--- a/vm/internal/backend/load.go
+++ b/vm/internal/backend/load.go
@@ -3,12 +3,13 @@ package backend
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
-	"os"
+	"github.com/docker/volumes-backup-extension/internal/log"
 )
 
 func Load(ctx context.Context, client *client.Client, volumeName, image string) error {

--- a/vm/internal/backend/save.go
+++ b/vm/internal/backend/save.go
@@ -3,13 +3,14 @@ package backend
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/felipecruz91/vackup-docker-extension/internal"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
-	"os"
+	"github.com/docker/volumes-backup-extension/internal"
+	"github.com/docker/volumes-backup-extension/internal/log"
 )
 
 func Save(ctx context.Context, client *client.Client, volumeName, image string) error {

--- a/vm/internal/backend/size.go
+++ b/vm/internal/backend/size.go
@@ -4,17 +4,18 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
-	"github.com/felipecruz91/vackup-docker-extension/internal"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/docker/volumes-backup-extension/internal"
+	"github.com/docker/volumes-backup-extension/internal/log"
 )
 
 type VolumeSize struct {

--- a/vm/internal/handler/clone.go
+++ b/vm/internal/handler/clone.go
@@ -30,32 +30,37 @@ func (h *Handler) CloneVolume(ctx echo.Context) error {
 	log.Infof("volumeName: %s", volumeName)
 	log.Infof("destVolume: %s", destVolume)
 
+	cli, err := h.DockerClient()
+	if err != nil {
+		log.Error(err)
+		return ctx.String(http.StatusInternalServerError, err.Error())
+	}
+
 	defer func() {
 		h.ProgressCache.Lock()
 		delete(h.ProgressCache.m, volumeName)
 		h.ProgressCache.Unlock()
-		_ = backend.TriggerUIRefresh(ctx.Request().Context(), h.DockerClient)
+		_ = backend.TriggerUIRefresh(ctx.Request().Context(), cli)
 	}()
 
 	h.ProgressCache.Lock()
 	h.ProgressCache.m[volumeName] = "clone"
 	h.ProgressCache.Unlock()
 
-	err := backend.TriggerUIRefresh(ctx.Request().Context(), h.DockerClient)
-	if err != nil {
+	if err := backend.TriggerUIRefresh(ctx.Request().Context(), cli); err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
 	// Stop container(s)
-	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctx.Request().Context(), h.DockerClient, volumeName)
+	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctx.Request().Context(), cli, volumeName)
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
 	// Ensure the image is present before creating the container
-	reader, err := h.DockerClient.ImagePull(ctx.Request().Context(), internal.BusyboxImage, types.ImagePullOptions{
+	reader, err := cli.ImagePull(ctx.Request().Context(), internal.BusyboxImage, types.ImagePullOptions{
 		Platform: "linux/" + runtime.GOARCH,
 	})
 	if err != nil {
@@ -67,7 +72,7 @@ func (h *Handler) CloneVolume(ctx echo.Context) error {
 	}
 
 	// Clone
-	resp, err := h.DockerClient.ContainerCreate(ctx.Request().Context(), &container.Config{
+	resp, err := cli.ContainerCreate(ctx.Request().Context(), &container.Config{
 		Image:        internal.BusyboxImage,
 		AttachStdout: true,
 		AttachStderr: true,
@@ -92,13 +97,13 @@ func (h *Handler) CloneVolume(ctx echo.Context) error {
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
-	if err := h.DockerClient.ContainerStart(ctx.Request().Context(), resp.ID, types.ContainerStartOptions{}); err != nil {
+	if err := cli.ContainerStart(ctx.Request().Context(), resp.ID, types.ContainerStartOptions{}); err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
 	var exitCode int64
-	statusCh, errCh := h.DockerClient.ContainerWait(ctx.Request().Context(), resp.ID, container.WaitConditionNotRunning)
+	statusCh, errCh := cli.ContainerWait(ctx.Request().Context(), resp.ID, container.WaitConditionNotRunning)
 	select {
 	case err := <-errCh:
 		if err != nil {
@@ -110,7 +115,7 @@ func (h *Handler) CloneVolume(ctx echo.Context) error {
 		exitCode = status.StatusCode
 	}
 
-	out, err := h.DockerClient.ContainerLogs(ctx.Request().Context(), resp.ID, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true})
+	out, err := cli.ContainerLogs(ctx.Request().Context(), resp.ID, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true})
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
@@ -126,14 +131,14 @@ func (h *Handler) CloneVolume(ctx echo.Context) error {
 		return ctx.String(http.StatusInternalServerError, fmt.Sprintf("container exited with status code %d\n", exitCode))
 	}
 
-	err = h.DockerClient.ContainerRemove(ctx.Request().Context(), resp.ID, types.ContainerRemoveOptions{})
+	err = cli.ContainerRemove(ctx.Request().Context(), resp.ID, types.ContainerRemoveOptions{})
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
 	// Start container(s)
-	err = backend.StartContainersAttachedToVolume(ctx.Request().Context(), h.DockerClient, stoppedContainers)
+	err = backend.StartContainersAttachedToVolume(ctx.Request().Context(), cli, stoppedContainers)
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())

--- a/vm/internal/handler/clone.go
+++ b/vm/internal/handler/clone.go
@@ -2,17 +2,18 @@ package handler
 
 import (
 	"fmt"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/felipecruz91/vackup-docker-extension/internal"
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
-	"github.com/labstack/echo"
 	"io"
 	"net/http"
 	"os"
 	"runtime"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/volumes-backup-extension/internal"
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/docker/volumes-backup-extension/internal/log"
+	"github.com/labstack/echo"
 )
 
 func (h *Handler) CloneVolume(ctx echo.Context) error {

--- a/vm/internal/handler/clone_test.go
+++ b/vm/internal/handler/clone_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
 	"github.com/docker/volumes-backup-extension/internal/backend"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/require"
@@ -43,7 +44,7 @@ func TestCloneVolume(t *testing.T) {
 	c.SetPath("/volumes/:volume/clone")
 	c.SetParamNames("volume")
 	c.SetParamValues(volume)
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return setupDockerClient(t), nil })
 
 	// Create volume
 	_, err := cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{
@@ -85,13 +86,17 @@ func TestCloneVolume(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
+	dockerClient, err := h.DockerClient()
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Check volume has been cloned and contains the expected data
-	clonedVolumeResp, err := h.DockerClient.VolumeList(context.Background(), filters.NewArgs(filters.Arg("name", destVolume)))
+	clonedVolumeResp, err := dockerClient.VolumeList(context.Background(), filters.NewArgs(filters.Arg("name", destVolume)))
 	if err != nil {
 		t.Fatal(err)
 	}
 	require.Len(t, clonedVolumeResp.Volumes, 1)
-	sizes := backend.GetVolumesSize(context.Background(), h.DockerClient, destVolume)
+	sizes := backend.GetVolumesSize(context.Background(), dockerClient, destVolume)
 	require.Equal(t, int64(16000), sizes[destVolume].Bytes)
 	require.Equal(t, "16.0 kB", sizes[destVolume].Human)
 }

--- a/vm/internal/handler/clone_test.go
+++ b/vm/internal/handler/clone_test.go
@@ -2,13 +2,6 @@ package handler
 
 import (
 	"context"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
-	volumetypes "github.com/docker/docker/api/types/volume"
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +9,14 @@ import (
 	"os"
 	"runtime"
 	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCloneVolume(t *testing.T) {

--- a/vm/internal/handler/delete.go
+++ b/vm/internal/handler/delete.go
@@ -1,10 +1,11 @@
 package handler
 
 import (
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
-	"github.com/labstack/echo"
 	"net/http"
+
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/docker/volumes-backup-extension/internal/log"
+	"github.com/labstack/echo"
 )
 
 func (h *Handler) DeleteVolume(ctx echo.Context) error {

--- a/vm/internal/handler/export.go
+++ b/vm/internal/handler/export.go
@@ -2,8 +2,6 @@ package handler
 
 import (
 	"fmt"
-	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/felipecruz91/vackup-docker-extension/internal"
 	"io"
 	"net/http"
 	"os"
@@ -11,10 +9,13 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/volumes-backup-extension/internal"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/docker/volumes-backup-extension/internal/log"
 	"github.com/labstack/echo"
 )
 

--- a/vm/internal/handler/export_test.go
+++ b/vm/internal/handler/export_test.go
@@ -5,11 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	volumetypes "github.com/docker/docker/api/types/volume"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -20,6 +15,13 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExportVolume(t *testing.T) {
@@ -52,7 +54,7 @@ func TestExportVolume(t *testing.T) {
 	c.SetPath("/volumes/:volume/export")
 	c.SetParamNames("volume")
 	c.SetParamValues(volume)
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return setupDockerClient(t), nil })
 
 	// Create volume
 	_, err := cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{

--- a/vm/internal/handler/handler.go
+++ b/vm/internal/handler/handler.go
@@ -2,14 +2,15 @@ package handler
 
 import (
 	"context"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
-	"github.com/felipecruz91/vackup-docker-extension/internal"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
-	"golang.org/x/sync/errgroup"
 	"io"
 	"os"
 	"runtime"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/docker/volumes-backup-extension/internal"
+	"github.com/docker/volumes-backup-extension/internal/log"
+	"golang.org/x/sync/errgroup"
 )
 
 type Handler struct {

--- a/vm/internal/handler/handler.go
+++ b/vm/internal/handler/handler.go
@@ -14,15 +14,19 @@ import (
 )
 
 type Handler struct {
-	DockerClient  *client.Client
+	DockerClient  func() (*client.Client, error)
 	ProgressCache *ProgressCache
 }
 
-func New(ctx context.Context, cli *client.Client) *Handler {
+func New(ctx context.Context, cliFactory func() (*client.Client, error)) *Handler {
+	cli, err := cliFactory()
+	if err != nil {
+		log.Fatal(err)
+	}
 	pullImagesIfNotPresent(ctx, cli)
 
 	return &Handler{
-		DockerClient: cli,
+		DockerClient: cliFactory,
 		ProgressCache: &ProgressCache{
 			m: make(map[string]string),
 		},

--- a/vm/internal/handler/import.go
+++ b/vm/internal/handler/import.go
@@ -30,25 +30,30 @@ func (h *Handler) ImportTarGzFile(ctx echo.Context) error {
 	log.Infof("volumeName: %s", volumeName)
 	log.Infof("path: %s", path)
 
+	cli, err := h.DockerClient()
+	if err != nil {
+		log.Error(err)
+		return ctx.String(http.StatusInternalServerError, err.Error())
+	}
+
 	defer func() {
 		h.ProgressCache.Lock()
 		delete(h.ProgressCache.m, volumeName)
 		h.ProgressCache.Unlock()
-		_ = backend.TriggerUIRefresh(ctx.Request().Context(), h.DockerClient)
+		_ = backend.TriggerUIRefresh(ctx.Request().Context(), cli)
 	}()
 
 	h.ProgressCache.Lock()
 	h.ProgressCache.m[volumeName] = "import"
 	h.ProgressCache.Unlock()
 
-	err := backend.TriggerUIRefresh(ctx.Request().Context(), h.DockerClient)
-	if err != nil {
+	if err := backend.TriggerUIRefresh(ctx.Request().Context(), cli); err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
 	// Stop container(s)
-	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctx.Request().Context(), h.DockerClient, volumeName)
+	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctx.Request().Context(), cli, volumeName)
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
@@ -62,7 +67,7 @@ func (h *Handler) ImportTarGzFile(ctx echo.Context) error {
 	log.Infof("binds: %+v", binds)
 
 	// Ensure the image is present before creating the container
-	reader, err := h.DockerClient.ImagePull(ctx.Request().Context(), internal.BusyboxImage, types.ImagePullOptions{
+	reader, err := cli.ImagePull(ctx.Request().Context(), internal.BusyboxImage, types.ImagePullOptions{
 		Platform: "linux/" + runtime.GOARCH,
 	})
 	if err != nil {
@@ -73,7 +78,7 @@ func (h *Handler) ImportTarGzFile(ctx echo.Context) error {
 		return err
 	}
 
-	resp, err := h.DockerClient.ContainerCreate(ctx.Request().Context(), &container.Config{
+	resp, err := cli.ContainerCreate(ctx.Request().Context(), &container.Config{
 		Image:        internal.BusyboxImage,
 		AttachStdout: true,
 		AttachStderr: true,
@@ -97,13 +102,13 @@ func (h *Handler) ImportTarGzFile(ctx echo.Context) error {
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
-	if err := h.DockerClient.ContainerStart(ctx.Request().Context(), resp.ID, types.ContainerStartOptions{}); err != nil {
+	if err := cli.ContainerStart(ctx.Request().Context(), resp.ID, types.ContainerStartOptions{}); err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
 	var exitCode int64
-	statusCh, errCh := h.DockerClient.ContainerWait(ctx.Request().Context(), resp.ID, container.WaitConditionNotRunning)
+	statusCh, errCh := cli.ContainerWait(ctx.Request().Context(), resp.ID, container.WaitConditionNotRunning)
 	select {
 	case err := <-errCh:
 		if err != nil {
@@ -115,7 +120,7 @@ func (h *Handler) ImportTarGzFile(ctx echo.Context) error {
 		exitCode = status.StatusCode
 	}
 
-	out, err := h.DockerClient.ContainerLogs(ctx.Request().Context(), resp.ID, types.ContainerLogsOptions{ShowStdout: true})
+	out, err := cli.ContainerLogs(ctx.Request().Context(), resp.ID, types.ContainerLogsOptions{ShowStdout: true})
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
@@ -131,14 +136,14 @@ func (h *Handler) ImportTarGzFile(ctx echo.Context) error {
 		return ctx.String(http.StatusInternalServerError, fmt.Sprintf("container exited with status code %d\n", exitCode))
 	}
 
-	err = h.DockerClient.ContainerRemove(ctx.Request().Context(), resp.ID, types.ContainerRemoveOptions{})
+	err = cli.ContainerRemove(ctx.Request().Context(), resp.ID, types.ContainerRemoveOptions{})
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
 	// Start container(s)
-	err = backend.StartContainersAttachedToVolume(ctx.Request().Context(), h.DockerClient, stoppedContainers)
+	err = backend.StartContainersAttachedToVolume(ctx.Request().Context(), cli, stoppedContainers)
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())

--- a/vm/internal/handler/import.go
+++ b/vm/internal/handler/import.go
@@ -2,17 +2,18 @@ package handler
 
 import (
 	"fmt"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/felipecruz91/vackup-docker-extension/internal"
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
-	"github.com/labstack/echo"
 	"io"
 	"net/http"
 	"os"
 	"runtime"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/volumes-backup-extension/internal"
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/docker/volumes-backup-extension/internal/log"
+	"github.com/labstack/echo"
 )
 
 func (h *Handler) ImportTarGzFile(ctx echo.Context) error {

--- a/vm/internal/handler/import_test.go
+++ b/vm/internal/handler/import_test.go
@@ -2,12 +2,6 @@ package handler
 
 import (
 	"context"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	volumetypes "github.com/docker/docker/api/types/volume"
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +10,13 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/require"
 )
 
 func TestImportTarGzFile(t *testing.T) {

--- a/vm/internal/handler/import_test.go
+++ b/vm/internal/handler/import_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
 	"github.com/docker/volumes-backup-extension/internal/backend"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/require"
@@ -44,7 +45,7 @@ func TestImportTarGzFile(t *testing.T) {
 	c.SetPath("/volumes/:volume/import")
 	c.SetParamNames("volume")
 	c.SetParamValues(volume)
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return setupDockerClient(t), nil })
 
 	// Create volume
 	_, err = cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{
@@ -90,7 +91,7 @@ func TestImportTarGzFileShouldRemovePreviousVolumeData(t *testing.T) {
 	c.SetPath("/volumes/:volume/import")
 	c.SetParamNames("volume")
 	c.SetParamValues(volume)
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return setupDockerClient(t), nil })
 
 	// Create volume
 	_, err = cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{
@@ -126,7 +127,7 @@ func TestImportTarGzFileShouldRemovePreviousVolumeData(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := h.DockerClient.ContainerStart(context.Background(), resp.ID, types.ContainerStartOptions{}); err != nil {
+	if err := cli.ContainerStart(context.Background(), resp.ID, types.ContainerStartOptions{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vm/internal/handler/load.go
+++ b/vm/internal/handler/load.go
@@ -1,10 +1,11 @@
 package handler
 
 import (
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
-	"github.com/labstack/echo"
 	"net/http"
+
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/docker/volumes-backup-extension/internal/log"
+	"github.com/labstack/echo"
 )
 
 func (h *Handler) LoadImage(ctx echo.Context) error {

--- a/vm/internal/handler/load.go
+++ b/vm/internal/handler/load.go
@@ -22,38 +22,42 @@ func (h *Handler) LoadImage(ctx echo.Context) error {
 	log.Infof("volumeName: %s", volumeName)
 	log.Infof("image: %s", image)
 
+	cli, err := h.DockerClient()
+	if err != nil {
+		log.Error(err)
+		return ctx.String(http.StatusInternalServerError, err.Error())
+	}
 	defer func() {
 		h.ProgressCache.Lock()
 		delete(h.ProgressCache.m, volumeName)
 		h.ProgressCache.Unlock()
-		_ = backend.TriggerUIRefresh(ctx.Request().Context(), h.DockerClient)
+		_ = backend.TriggerUIRefresh(ctx.Request().Context(), cli)
 	}()
 
 	h.ProgressCache.Lock()
 	h.ProgressCache.m[volumeName] = "load"
 	h.ProgressCache.Unlock()
 
-	err := backend.TriggerUIRefresh(ctx.Request().Context(), h.DockerClient)
-	if err != nil {
+	if err := backend.TriggerUIRefresh(ctx.Request().Context(), cli); err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
-	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctx.Request().Context(), h.DockerClient, volumeName)
+	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctx.Request().Context(), cli, volumeName)
 	if err != nil {
 		log.Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	// Load
-	err = backend.Load(ctx.Request().Context(), h.DockerClient, volumeName, image)
+	err = backend.Load(ctx.Request().Context(), cli, volumeName, image)
 	if err != nil {
 		log.Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	// Start container(s)
-	err = backend.StartContainersAttachedToVolume(ctx.Request().Context(), h.DockerClient, stoppedContainers)
+	err = backend.StartContainersAttachedToVolume(ctx.Request().Context(), cli, stoppedContainers)
 	if err != nil {
 		log.Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/vm/internal/handler/load_test.go
+++ b/vm/internal/handler/load_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
 	"github.com/docker/volumes-backup-extension/internal/backend"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/require"
@@ -57,7 +58,7 @@ func TestLoadImage(t *testing.T) {
 	c.SetPath("/volumes/:volume/load")
 	c.SetParamNames("volume")
 	c.SetParamValues(volume)
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return setupDockerClient(t), nil })
 
 	// Create volume
 	_, err = cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{
@@ -117,7 +118,7 @@ func TestLoadImageShouldRemovePreviousVolumeData(t *testing.T) {
 	c.SetPath("/volumes/:volume/load")
 	c.SetParamNames("volume")
 	c.SetParamValues(volume)
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return setupDockerClient(t), nil })
 
 	// Create volume
 	_, err = cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{
@@ -153,7 +154,7 @@ func TestLoadImageShouldRemovePreviousVolumeData(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := h.DockerClient.ContainerStart(context.Background(), postgresResp.ID, types.ContainerStartOptions{}); err != nil {
+	if err := cli.ContainerStart(context.Background(), postgresResp.ID, types.ContainerStartOptions{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vm/internal/handler/load_test.go
+++ b/vm/internal/handler/load_test.go
@@ -2,12 +2,6 @@ package handler
 
 import (
 	"context"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	volumetypes "github.com/docker/docker/api/types/volume"
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +10,13 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadImage(t *testing.T) {

--- a/vm/internal/handler/pull.go
+++ b/vm/internal/handler/pull.go
@@ -1,15 +1,16 @@
 package handler
 
 import (
-	"github.com/docker/distribution/reference"
-	dockertypes "github.com/docker/docker/api/types"
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
-	"github.com/labstack/echo"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/docker/distribution/reference"
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/docker/volumes-backup-extension/internal/log"
+	"github.com/labstack/echo"
+	"github.com/sirupsen/logrus"
 )
 
 type PullRequest struct {

--- a/vm/internal/handler/pull_test.go
+++ b/vm/internal/handler/pull_test.go
@@ -5,14 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"github.com/docker/docker/api/types"
-	dockertypes "github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	volumetypes "github.com/docker/docker/api/types/volume"
-	"github.com/docker/go-connections/nat"
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"log"
@@ -24,6 +16,15 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/docker/docker/api/types"
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/go-connections/nat"
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPullVolume(t *testing.T) {

--- a/vm/internal/handler/push.go
+++ b/vm/internal/handler/push.go
@@ -40,18 +40,23 @@ func (h *Handler) PushVolume(ctx echo.Context) error {
 	log.Infof("reference: %s", request.Reference)
 	log.Infof("received push request for volume %s\n", volumeName)
 
+	cli, err := h.DockerClient()
+	if err != nil {
+		log.Error(err)
+		return ctx.String(http.StatusInternalServerError, err.Error())
+	}
 	defer func() {
 		h.ProgressCache.Lock()
 		delete(h.ProgressCache.m, volumeName)
 		h.ProgressCache.Unlock()
-		_ = backend.TriggerUIRefresh(ctxReq, h.DockerClient)
+		_ = backend.TriggerUIRefresh(ctxReq, cli)
 	}()
 
 	h.ProgressCache.Lock()
 	h.ProgressCache.m[volumeName] = "push"
 	h.ProgressCache.Unlock()
 
-	err := backend.TriggerUIRefresh(ctxReq, h.DockerClient)
+	err = backend.TriggerUIRefresh(ctxReq, cli)
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
@@ -75,20 +80,20 @@ func (h *Handler) PushVolume(ctx echo.Context) error {
 	log.Infof("parsedRef.String(): %s", parsedRef.String())
 
 	// Stop container(s)
-	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctxReq, h.DockerClient, volumeName)
+	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctxReq, cli, volumeName)
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
 	// Save the content of the volume into an image
-	if err := backend.Save(ctxReq, h.DockerClient, volumeName, parsedRef.String()); err != nil {
+	if err := backend.Save(ctxReq, cli, volumeName, parsedRef.String()); err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
 	// Push the image to registry
-	pushResp, err := h.DockerClient.ImagePush(ctxReq, parsedRef.String(), dockertypes.ImagePushOptions{
+	pushResp, err := cli.ImagePush(ctxReq, parsedRef.String(), dockertypes.ImagePushOptions{
 		RegistryAuth: request.Base64EncodedAuth,
 	})
 	if err != nil {
@@ -122,7 +127,7 @@ func (h *Handler) PushVolume(ctx echo.Context) error {
 	}
 
 	// Start container(s)
-	err = backend.StartContainersAttachedToVolume(ctxReq, h.DockerClient, stoppedContainers)
+	err = backend.StartContainersAttachedToVolume(ctxReq, cli, stoppedContainers)
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())

--- a/vm/internal/handler/push.go
+++ b/vm/internal/handler/push.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/docker/distribution/reference"
 	dockertypes "github.com/docker/docker/api/types"
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/docker/volumes-backup-extension/internal/log"
 	"github.com/labstack/echo"
 )
 

--- a/vm/internal/handler/push_test.go
+++ b/vm/internal/handler/push_test.go
@@ -5,12 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	volumetypes "github.com/docker/docker/api/types/volume"
-	"github.com/docker/go-connections/nat"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -20,6 +14,14 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPushVolume(t *testing.T) {
@@ -57,7 +59,7 @@ func TestPushVolume(t *testing.T) {
 	c.SetPath("/volumes/:volume/push")
 	c.SetParamNames("volume")
 	c.SetParamValues(volume)
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return setupDockerClient(t), nil })
 
 	// Create volume
 	_, err := cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{
@@ -125,7 +127,7 @@ func TestPushVolume(t *testing.T) {
 
 	registryContainerID = resp2.ID
 
-	if err := h.DockerClient.ContainerStart(c.Request().Context(), registryContainerID, types.ContainerStartOptions{}); err != nil {
+	if err := cli.ContainerStart(c.Request().Context(), registryContainerID, types.ContainerStartOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -196,7 +198,7 @@ func TestPushVolumeUsingCorrectAuth(t *testing.T) {
 	c.SetPath("/volumes/:volume/push")
 	c.SetParamNames("volume")
 	c.SetParamValues(volume)
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return setupDockerClient(t), nil })
 
 	// Create volume
 	_, err := cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{
@@ -280,7 +282,7 @@ func TestPushVolumeUsingCorrectAuth(t *testing.T) {
 
 	registryContainerID = resp2.ID
 
-	if err := h.DockerClient.ContainerStart(c.Request().Context(), registryContainerID, types.ContainerStartOptions{}); err != nil {
+	if err := cli.ContainerStart(c.Request().Context(), registryContainerID, types.ContainerStartOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -360,7 +362,7 @@ func TestPushVolumeUsingWrongAuthShouldFail(t *testing.T) {
 	c.SetPath("/volumes/:volume/push")
 	c.SetParamNames("volume")
 	c.SetParamValues(volume)
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return setupDockerClient(t), nil })
 
 	// Create volume
 	_, err := cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{
@@ -444,7 +446,7 @@ func TestPushVolumeUsingWrongAuthShouldFail(t *testing.T) {
 
 	registryContainerID = resp2.ID
 
-	if err := h.DockerClient.ContainerStart(c.Request().Context(), registryContainerID, types.ContainerStartOptions{}); err != nil {
+	if err := cli.ContainerStart(c.Request().Context(), registryContainerID, types.ContainerStartOptions{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vm/internal/handler/save.go
+++ b/vm/internal/handler/save.go
@@ -1,10 +1,11 @@
 package handler
 
 import (
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
-	"github.com/labstack/echo"
 	"net/http"
+
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/docker/volumes-backup-extension/internal/log"
+	"github.com/labstack/echo"
 )
 
 func (h *Handler) SaveVolume(ctx echo.Context) error {

--- a/vm/internal/handler/save.go
+++ b/vm/internal/handler/save.go
@@ -23,38 +23,43 @@ func (h *Handler) SaveVolume(ctx echo.Context) error {
 	log.Infof("volumeName: %s", volumeName)
 	log.Infof("image: %s", image)
 
+	cli, err := h.DockerClient()
+	if err != nil {
+		log.Error(err)
+		return ctx.String(http.StatusInternalServerError, err.Error())
+	}
 	defer func() {
 		h.ProgressCache.Lock()
 		delete(h.ProgressCache.m, volumeName)
 		h.ProgressCache.Unlock()
-		_ = backend.TriggerUIRefresh(ctxReq, h.DockerClient)
+		_ = backend.TriggerUIRefresh(ctxReq, cli)
 	}()
 
 	h.ProgressCache.Lock()
 	h.ProgressCache.m[volumeName] = "save"
 	h.ProgressCache.Unlock()
 
-	err := backend.TriggerUIRefresh(ctxReq, h.DockerClient)
+	err = backend.TriggerUIRefresh(ctxReq, cli)
 	if err != nil {
 		log.Error(err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
 	// Stop container(s)
-	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctxReq, h.DockerClient, volumeName)
+	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctxReq, cli, volumeName)
 	if err != nil {
 		log.Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	// Save volume into an image
-	if err := backend.Save(ctxReq, h.DockerClient, volumeName, image); err != nil {
+	if err := backend.Save(ctxReq, cli, volumeName, image); err != nil {
 		log.Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	// Start container(s)
-	err = backend.StartContainersAttachedToVolume(ctxReq, h.DockerClient, stoppedContainers)
+	err = backend.StartContainersAttachedToVolume(ctxReq, cli, stoppedContainers)
 	if err != nil {
 		log.Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/vm/internal/handler/save_test.go
+++ b/vm/internal/handler/save_test.go
@@ -2,12 +2,6 @@ package handler
 
 import (
 	"context"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
-	volumetypes "github.com/docker/docker/api/types/volume"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +10,14 @@ import (
 	"runtime"
 	"strconv"
 	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSaveVolume(t *testing.T) {
@@ -48,7 +50,7 @@ func TestSaveVolume(t *testing.T) {
 	c.SetPath("/volumes/:volume/save")
 	c.SetParamNames("volume")
 	c.SetParamValues(volume)
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return cli, nil })
 
 	// Create volume
 	_, err := cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{

--- a/vm/internal/handler/size.go
+++ b/vm/internal/handler/size.go
@@ -1,9 +1,10 @@
 package handler
 
 import (
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/labstack/echo"
 	"net/http"
+
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/labstack/echo"
 )
 
 func (h *Handler) VolumeSize(ctx echo.Context) error {

--- a/vm/internal/handler/size.go
+++ b/vm/internal/handler/size.go
@@ -4,13 +4,19 @@ import (
 	"net/http"
 
 	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/docker/volumes-backup-extension/internal/log"
 	"github.com/labstack/echo"
 )
 
 func (h *Handler) VolumeSize(ctx echo.Context) error {
 	volumeName := ctx.Param("volume")
+	cli, err := h.DockerClient()
+	if err != nil {
+		log.Error(err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
 
-	m := backend.GetVolumesSize(ctx.Request().Context(), h.DockerClient, volumeName)
+	m := backend.GetVolumesSize(ctx.Request().Context(), cli, volumeName)
 
 	return ctx.JSON(http.StatusOK, m[volumeName])
 }

--- a/vm/internal/handler/size_test.go
+++ b/vm/internal/handler/size_test.go
@@ -2,17 +2,19 @@ package handler
 
 import (
 	"context"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	volumetypes "github.com/docker/docker/api/types/volume"
-	"github.com/labstack/echo"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"runtime"
 	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVolumeSize(t *testing.T) {
@@ -35,7 +37,7 @@ func TestVolumeSize(t *testing.T) {
 	c.SetPath("/volumes/:volume/size")
 	c.SetParamNames("volume")
 	c.SetParamValues(volume)
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return setupDockerClient(t), nil })
 
 	// Create volume
 	_, err := cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{

--- a/vm/internal/handler/volumes.go
+++ b/vm/internal/handler/volumes.go
@@ -24,7 +24,12 @@ type VolumeData struct {
 }
 
 func (h *Handler) Volumes(ctx echo.Context) error {
-	v, err := h.DockerClient.VolumeList(ctx.Request().Context(), filters.NewArgs())
+	cli, err := h.DockerClient()
+	if err != nil {
+		log.Error(err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	v, err := cli.VolumeList(ctx.Request().Context(), filters.NewArgs())
 	if err != nil {
 		log.Error(err)
 	}
@@ -37,7 +42,7 @@ func (h *Handler) Volumes(ctx echo.Context) error {
 	// Calculating the volume size by spinning a container that execs "du " **per volume** is too time-consuming.
 	// To reduce the time it takes, we get the volumes size by running only one container that execs "du"
 	// into the /var/lib/docker/volumes inside the VM.
-	volumesSize := backend.GetVolumesSize(ctx.Request().Context(), h.DockerClient, "*")
+	volumesSize := backend.GetVolumesSize(ctx.Request().Context(), cli, "*")
 	res.Lock()
 	for k, v := range volumesSize {
 		entry, ok := res.data[k]
@@ -58,7 +63,7 @@ func (h *Handler) Volumes(ctx echo.Context) error {
 		wg.Add(2)
 		go func(volumeName string) {
 			defer wg.Done()
-			driver := backend.GetVolumeDriver(context.Background(), h.DockerClient, volumeName) // TODO: use request context
+			driver := backend.GetVolumeDriver(context.Background(), cli, volumeName) // TODO: use request context
 			res.Lock()
 			defer res.Unlock()
 			entry, ok := res.data[volumeName]
@@ -74,7 +79,7 @@ func (h *Handler) Volumes(ctx echo.Context) error {
 
 		go func(volumeName string) {
 			defer wg.Done()
-			containers := backend.GetContainersForVolume(context.Background(), h.DockerClient, volumeName) // TODO: use request context
+			containers := backend.GetContainersForVolume(context.Background(), cli, volumeName) // TODO: use request context
 			res.Lock()
 			defer res.Unlock()
 			entry, ok := res.data[volumeName]

--- a/vm/internal/handler/volumes.go
+++ b/vm/internal/handler/volumes.go
@@ -2,12 +2,13 @@ package handler
 
 import (
 	"context"
-	"github.com/docker/docker/api/types/filters"
-	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
-	"github.com/labstack/echo"
 	"net/http"
 	"sync"
+
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/docker/volumes-backup-extension/internal/log"
+	"github.com/labstack/echo"
 )
 
 type VolumesResponse struct {

--- a/vm/internal/handler/volumes_test.go
+++ b/vm/internal/handler/volumes_test.go
@@ -3,13 +3,14 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 func TestVolumes(t *testing.T) {
@@ -26,7 +27,7 @@ func TestVolumes(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.SetPath("/volumes")
-	h := New(c.Request().Context(), setupDockerClient(t))
+	h := New(c.Request().Context(), func() (*client.Client, error) { return cli, nil })
 
 	// Create volume
 	_, err := cli.VolumeCreate(c.Request().Context(), volumetypes.VolumeCreateBody{

--- a/vm/main.go
+++ b/vm/main.go
@@ -49,12 +49,15 @@ func main() {
 	}
 	router.Listener = ln
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cliFactory := func() (*client.Client, error) {
+
+		return client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	}
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	h = handler.New(context.Background(), cli)
+	h = handler.New(context.Background(), cliFactory)
 
 	router.GET("/progress", h.ActionsInProgress)
 	router.GET("/volumes", h.Volumes)

--- a/vm/main.go
+++ b/vm/main.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/docker/docker/client"
-	"github.com/felipecruz91/vackup-docker-extension/internal/handler"
-	"github.com/felipecruz91/vackup-docker-extension/internal/log"
+	"github.com/docker/volumes-backup-extension/internal/handler"
+	"github.com/docker/volumes-backup-extension/internal/log"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 )


### PR DESCRIPTION
Keeping the docker engine cli in memory (in go binary) for a long time may cause all sorts of strange behaviour when waiting a long time (or resuming after a laptop sleep, the engine socket might not be valid anymore in memory)

This PR also renames the go module