### PR TITLE
Improve volume list performance

### DIFF
--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -116,7 +116,13 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=semver,pattern={{version}}
-
+          # The action will generate its own OCI labels that are not suitable for the Marketplace.
+          # We have to override them with the same values as the ones defined in the Dockerfile.
+          # https://github.com/docker/metadata-action#overwrite-labels
+          labels: |
+            org.opencontainers.image.title=Volumes Backup & Share
+            org.opencontainers.image.description=Back up, clone, restore, and share Docker volumes effortlessly.
+            org.opencontainers.image.vendor=Docker Inc.
       - name: Docker Build and Push to Docker Hub
         if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: docker/build-push-action@v2

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -307,6 +307,7 @@ export function App() {
 
   const {
     data: rows,
+    listVolumes,
     isLoading,
     isVolumesSizeLoading,
     setData,
@@ -403,11 +404,17 @@ export function App() {
   };
 
   const handleImportIntoNewDialogCompletion = (
-    actionSuccessfullyCompleted: boolean
+    actionSuccessfullyCompleted: boolean,
+    selectedVolumeName: string
   ) => {
     if (actionSuccessfullyCompleted) {
-      if (context.store.volume)
+      if (selectedVolumeName && context.store.volume) {
+        // the import is performed on an existing volume
         calculateVolumeSize(context.store.volume.volumeName);
+      } else {
+        // the import is performed on a new volume, so we fetch all volumes to populate the table
+        listVolumes();
+      }
     }
   };
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -92,6 +92,9 @@ export function App() {
 
   const [actionsInProgress, setActionsInProgress] = React.useState({});
 
+  const [recalculateVolumeSize, setRecalculateVolumeSize] =
+    React.useState<string>(null);
+
   const columns = [
     { field: "volumeDriver", headerName: "Driver", hide: true },
     {
@@ -415,12 +418,29 @@ export function App() {
   };
 
   const handleCloneDialogOnCompletion = (
+    clonedVolumeName: string,
     actionSuccessfullyCompleted: boolean
   ) => {
     if (actionSuccessfullyCompleted) {
-      listVolumes();
+      // Push new volume into the state
+      const rowsCopy = rows.slice(); // copy the array
+      rowsCopy.push({
+        id: rows.length,
+        volumeName: clonedVolumeName,
+        volumeDriver: "local",
+      });
+
+      setData(rowsCopy);
+      setRecalculateVolumeSize(clonedVolumeName);
     }
   };
+
+  useEffect(() => {
+    if (!recalculateVolumeSize) {
+      return;
+    }
+    calculateVolumeSize(recalculateVolumeSize);
+  }, [recalculateVolumeSize]);
 
   const handleTransferDialogClose = () => {
     setOpenTransferDialog(false);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -309,30 +309,6 @@ export function App() {
     setData,
   } = useGetVolumes();
 
-  useEffect(() => {
-    const volumeEvents = async () => {
-      console.log("listening to volume events...");
-      await ddClient.docker.cli.exec(
-        "events",
-        ["--format", `"{{ json . }}"`, "--filter", "type=volume"],
-        {
-          stream: {
-            onOutput() {
-              listVolumes();
-            },
-            onClose(exitCode) {
-              console.log("onClose with exit code " + exitCode);
-            },
-            splitOutputLines: true,
-          },
-        }
-      );
-    };
-
-    volumeEvents();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const getActionsInProgress = async () => {
     ddClient.extension.vm.service
       .get("/progress")
@@ -413,28 +389,33 @@ export function App() {
       });
   };
 
-  const handleExportDialogClose = (actionSuccessfullyCompleted: boolean) => {
+  const handleExportDialogClose = () => {
     setOpenExportDialog(false);
     context.actions.setVolume(null);
-    if (actionSuccessfullyCompleted) {
-      listVolumes();
-    }
   };
 
-  const handleImportIntoNewDialogClose = (
-    actionSuccessfullyCompleted: boolean
-  ) => {
+  const handleImportIntoNewDialogClose = () => {
     setOpenImportIntoNewDialog(false);
     context.actions.setVolume(null);
+  };
+
+  const handleImportIntoNewDialogCompletion = (
+    actionSuccessfullyCompleted: boolean
+  ) => {
     if (actionSuccessfullyCompleted) {
       if (context.store.volume)
         calculateVolumeSize(context.store.volume.volumeName);
     }
   };
 
-  const handleCloneDialogClose = (actionSuccessfullyCompleted: boolean) => {
+  const handleCloneDialogClose = () => {
     setOpenCloneDialog(false);
     context.actions.setVolume(null);
+  };
+
+  const handleCloneDialogOnCompletion = (
+    actionSuccessfullyCompleted: boolean
+  ) => {
     if (actionSuccessfullyCompleted) {
       listVolumes();
     }
@@ -545,6 +526,7 @@ export function App() {
               volumes={rows}
               open={openImportIntoNewDialog}
               onClose={handleImportIntoNewDialogClose}
+              onCompletion={handleImportIntoNewDialogCompletion}
             />
           )}
 
@@ -552,6 +534,7 @@ export function App() {
             <CloneDialog
               open={openCloneDialog}
               onClose={handleCloneDialogClose}
+              onCompletion={handleCloneDialogOnCompletion}
             />
           )}
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -103,6 +103,14 @@ export function App() {
       headerName: "Containers",
       flex: 1,
       renderCell: (params) => {
+        if (isVolumesSizeLoading) {
+          return (
+            <Box sx={{ width: "100%" }}>
+              <LinearProgress />
+            </Box>
+          );
+        }
+
         if (params.row.volumeContainers) {
           return (
             <Box display="flex" flexDirection="column">
@@ -119,7 +127,10 @@ export function App() {
       field: "volumeSize",
       headerName: "Size",
       renderCell: (params) => {
-        if (volumesSizeLoadingMap[params.row.volumeName]) {
+        if (
+          isVolumesSizeLoading ||
+          volumesSizeLoadingMap[params.row.volumeName]
+        ) {
           return (
             <Box sx={{ width: "100%" }}>
               <LinearProgress />
@@ -290,7 +301,13 @@ export function App() {
     }
   };
 
-  const { data: rows, isLoading, listVolumes, setData } = useGetVolumes();
+  const {
+    data: rows,
+    isLoading,
+    isVolumesSizeLoading,
+    listVolumes,
+    setData,
+  } = useGetVolumes();
 
   useEffect(() => {
     const volumeEvents = async () => {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -427,11 +427,14 @@ export function App() {
     context.actions.setVolume(null);
   };
 
-  const handleDeleteForeverDialogClose = (
-    actionSuccessfullyCompleted: boolean
-  ) => {
+  const handleDeleteForeverDialogClose = () => {
     setOpenDeleteForeverDialog(false);
     context.actions.setVolume(null);
+  };
+
+  const handleDeleteForeverDialogCompletion = (
+    actionSuccessfullyCompleted: boolean
+  ) => {
     if (actionSuccessfullyCompleted) {
       listVolumes();
     }
@@ -549,9 +552,8 @@ export function App() {
           {openDeleteForeverDialog && (
             <DeleteForeverDialog
               open={openDeleteForeverDialog}
-              onClose={(e) => {
-                handleDeleteForeverDialogClose(e);
-              }}
+              onClose={handleDeleteForeverDialogClose}
+              onCompletion={handleDeleteForeverDialogCompletion}
             />
           )}
         </Grid>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -309,7 +309,6 @@ export function App() {
     data: rows,
     isLoading,
     isVolumesSizeLoading,
-    listVolumes,
     setData,
   } = useGetVolumes();
 
@@ -422,8 +421,7 @@ export function App() {
     actionSuccessfullyCompleted: boolean
   ) => {
     if (actionSuccessfullyCompleted) {
-      // Push new volume into the state
-      const rowsCopy = rows.slice(); // copy the array
+      const rowsCopy = rows.slice();
       rowsCopy.push({
         id: rows.length,
         volumeName: clonedVolumeName,
@@ -455,8 +453,16 @@ export function App() {
   const handleDeleteForeverDialogCompletion = (
     actionSuccessfullyCompleted: boolean
   ) => {
-    if (actionSuccessfullyCompleted) {
-      listVolumes();
+    if (actionSuccessfullyCompleted && context.store.volume) {
+      const rowsCopy = rows.slice();
+      const index = rowsCopy.findIndex(
+        (element) => element.volumeName === context.store.volume.volumeName
+      );
+      if (index > -1) {
+        rowsCopy.splice(index, 1);
+      }
+
+      setData(rowsCopy);
     }
   };
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -15,6 +15,7 @@ import {
   CircularProgress,
   Grid,
   LinearProgress,
+  Skeleton,
   Stack,
   Tooltip,
   Typography,
@@ -106,7 +107,7 @@ export function App() {
         if (isVolumesSizeLoading) {
           return (
             <Box sx={{ width: "100%" }}>
-              <LinearProgress />
+              <Skeleton animation="wave" />
             </Box>
           );
         }
@@ -133,7 +134,7 @@ export function App() {
         ) {
           return (
             <Box sx={{ width: "100%" }}>
-              <LinearProgress />
+              <Skeleton animation="wave" />
             </Box>
           );
         }

--- a/ui/src/components/CloneDialog.tsx
+++ b/ui/src/components/CloneDialog.tsx
@@ -15,7 +15,8 @@ const ddClient = createDockerDesktopClient();
 
 interface Props {
   open: boolean;
-  onClose(v?: boolean): void;
+  onClose(): void;
+  onCompletion(v?: boolean): void;
 }
 
 export default function CloneDialog({ ...props }: Props) {
@@ -49,8 +50,11 @@ export default function CloneDialog({ ...props }: Props) {
         sendNotification.error(
           `Failed to clone volume ${context.store.volume.volumeName} to destination volume ${volumeName}: ${error.stderr} Exit code: ${error.code}`
         );
+      })
+      .finally(() => {
+        props.onCompletion(true);
       });
-    props.onClose(true);
+    props.onClose();
   };
 
   return (
@@ -89,7 +93,7 @@ export default function CloneDialog({ ...props }: Props) {
           variant="outlined"
           onClick={() => {
             track({ action: "CloneVolumeCancel" });
-            props.onClose(false);
+            props.onClose();
           }}
         >
           Cancel

--- a/ui/src/components/CloneDialog.tsx
+++ b/ui/src/components/CloneDialog.tsx
@@ -16,7 +16,7 @@ const ddClient = createDockerDesktopClient();
 interface Props {
   open: boolean;
   onClose(): void;
-  onCompletion(v?: boolean): void;
+  onCompletion(clonedVolumeName: string, v?: boolean): void;
 }
 
 export default function CloneDialog({ ...props }: Props) {
@@ -45,15 +45,15 @@ export default function CloneDialog({ ...props }: Props) {
             },
           ]
         );
+        props.onCompletion(volumeName, true);
       })
       .catch((error) => {
         sendNotification.error(
           `Failed to clone volume ${context.store.volume.volumeName} to destination volume ${volumeName}: ${error.stderr} Exit code: ${error.code}`
         );
-      })
-      .finally(() => {
-        props.onCompletion(true);
+        props.onCompletion(volumeName, false);
       });
+
     props.onClose();
   };
 

--- a/ui/src/components/DeleteForeverDialog.tsx
+++ b/ui/src/components/DeleteForeverDialog.tsx
@@ -15,7 +15,8 @@ const ddClient = createDockerDesktopClient();
 
 interface Props {
   open: boolean;
-  onClose(v?: boolean): void;
+  onClose(): void;
+  onCompletion(v?: boolean): void;
 }
 
 export default function DeleteForeverDialog({ ...props }: Props) {
@@ -30,13 +31,15 @@ export default function DeleteForeverDialog({ ...props }: Props) {
         sendNotification.info(
           `Volume ${context.store.volume.volumeName} deleted`
         );
+        props.onCompletion(true);
       })
       .catch((error) => {
         sendNotification.error(
           `Failed to delete volume ${context.store.volume.volumeName}: ${error.stderr} Exit code: ${error.code}`
         );
+        props.onCompletion(false);
       });
-    props.onClose(true);
+    props.onClose();
   };
 
   return (
@@ -53,7 +56,7 @@ export default function DeleteForeverDialog({ ...props }: Props) {
           variant="outlined"
           onClick={() => {
             track({ action: "DeleteVolumeCancel" });
-            props.onClose(false);
+            props.onClose();
           }}
         >
           Cancel

--- a/ui/src/components/ImportDialog.tsx
+++ b/ui/src/components/ImportDialog.tsx
@@ -33,11 +33,17 @@ const ddClient = createDockerDesktopClient();
 
 interface Props {
   open: boolean;
-  onClose(v: boolean): void;
+  onClose(): void;
+  onCompletion(v: boolean): void;
   volumes: IVolumeRow[];
 }
 
-export default function ImportDialog({ volumes, open, onClose }: Props) {
+export default function ImportDialog({
+  volumes,
+  open,
+  onClose,
+  onCompletion,
+}: Props) {
   const [fromRadioValue, setFromRadioValue] = useState<
     "file" | "image" | "pull-registry"
   >("file");
@@ -86,21 +92,39 @@ export default function ImportDialog({ volumes, open, onClose }: Props) {
       importVolume({
         volumeName: volumeId?.[0] || selectedVolumeName,
         path,
-      });
+      })
+        .then(() => {
+          onCompletion(true);
+        })
+        .catch(() => {
+          onCompletion(false);
+        });
     } else if (fromRadioValue === "image") {
       track({ ...metrics, importType: "fromLocalImage" });
       loadImage({
         volumeName: volumeId?.[0] || selectedVolumeName,
         imageName: image,
-      });
+      })
+        .then(() => {
+          onCompletion(true);
+        })
+        .catch(() => {
+          onCompletion(false);
+        });
     } else {
       track({ ...metrics, importType: "fromRegistry" });
       pullFromRegistry({
         imageName: registryImage,
         volumeId: volumeId?.[0],
-      });
+      })
+        .then(() => {
+          onCompletion(true);
+        })
+        .catch(() => {
+          onCompletion(false);
+        });
     }
-    onClose(true);
+    onClose();
   };
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -245,7 +269,7 @@ export default function ImportDialog({ volumes, open, onClose }: Props) {
           onClick={() => {
             track({ action: "ImportVolumeCancel" });
             setPath("");
-            onClose(false);
+            onClose();
           }}
         >
           Cancel

--- a/ui/src/components/ImportDialog.tsx
+++ b/ui/src/components/ImportDialog.tsx
@@ -34,7 +34,7 @@ const ddClient = createDockerDesktopClient();
 interface Props {
   open: boolean;
   onClose(): void;
-  onCompletion(v: boolean): void;
+  onCompletion(v: boolean, selectedVolumeName: string): void;
   volumes: IVolumeRow[];
 }
 
@@ -94,10 +94,10 @@ export default function ImportDialog({
         path,
       })
         .then(() => {
-          onCompletion(true);
+          onCompletion(true, selectedVolumeName);
         })
         .catch(() => {
-          onCompletion(false);
+          onCompletion(false, selectedVolumeName);
         });
     } else if (fromRadioValue === "image") {
       track({ ...metrics, importType: "fromLocalImage" });
@@ -106,10 +106,10 @@ export default function ImportDialog({
         imageName: image,
       })
         .then(() => {
-          onCompletion(true);
+          onCompletion(true, selectedVolumeName);
         })
         .catch(() => {
-          onCompletion(false);
+          onCompletion(false, selectedVolumeName);
         });
     } else {
       track({ ...metrics, importType: "fromRegistry" });
@@ -118,10 +118,10 @@ export default function ImportDialog({
         volumeId: volumeId?.[0],
       })
         .then(() => {
-          onCompletion(true);
+          onCompletion(true, selectedVolumeName);
         })
         .catch(() => {
-          onCompletion(false);
+          onCompletion(false, selectedVolumeName);
         });
     }
     onClose();

--- a/ui/src/hooks/useGetVolumes.ts
+++ b/ui/src/hooks/useGetVolumes.ts
@@ -83,16 +83,17 @@ export const useGetVolumes = () => {
               for (const key in rows) {
                 const row = rows[key];
 
-                if (containersMap[row.volumeName] === undefined) {
-                  continue;
+                if (containersMap[row.volumeName] !== undefined) {
+                  if (containersMap[row.volumeName].Containers?.length) {
+                    row.volumeContainers =
+                      containersMap[row.volumeName].Containers;
+                  }
                 }
 
-                if (containersMap[row.volumeName].Containers?.length) {
-                  row.volumeContainers =
-                    containersMap[row.volumeName].Containers;
+                if (sizesMap[row.volumeName] !== undefined) {
+                  row.volumeSize = sizesMap[row.volumeName].Human;
+                  row.volumeBytes = sizesMap[row.volumeName].Bytes;
                 }
-                row.volumeSize = sizesMap[row.volumeName].Human;
-                row.volumeBytes = sizesMap[row.volumeName].Bytes;
 
                 updatedRows.push(row);
               }

--- a/ui/src/hooks/useGetVolumes.ts
+++ b/ui/src/hooks/useGetVolumes.ts
@@ -111,6 +111,7 @@ export const useGetVolumes = () => {
   };
 
   return {
+    listVolumes,
     isLoading,
     isVolumesSizeLoading,
     data,

--- a/ui/src/hooks/useGetVolumes.ts
+++ b/ui/src/hooks/useGetVolumes.ts
@@ -111,7 +111,6 @@ export const useGetVolumes = () => {
   };
 
   return {
-    listVolumes,
     isLoading,
     isVolumesSizeLoading,
     data,

--- a/ui/src/hooks/useGetVolumes.ts
+++ b/ui/src/hooks/useGetVolumes.ts
@@ -58,37 +58,24 @@ export const useGetVolumes = () => {
 
           setIsVolumesSizeLoading(true);
           const fetchVolumesSize = new Promise<any>((resolve) => {
-            console.log("1/ fetchVolumesSize");
             ddClient.extension.vm.service
               .get("/volumes/size")
               .then((results: Record<string, string>) => {
-                console.log("2/ fetchVolumesSize");
-                console.log(results);
                 resolve(results);
               });
-            console.log("3/ fetchVolumesSize");
           });
 
           const fetchVolumesContainer = new Promise<any>((resolve) => {
-            console.log("1/ fetchVolumesContainer");
             ddClient.extension.vm.service
               .get("/volumes/container")
               .then((results: Record<string, string>) => {
-                console.log("2/ fetchVolumesContainer");
-                console.log(results);
                 resolve(results);
               });
-            console.log("3/ fetchVolumesContainer");
           });
 
           // Fetch volumes size and containers attached
-          console.log(
-            "Running Promise.all to fetch volumes size and containers attached..."
-          );
           Promise.all([fetchVolumesSize, fetchVolumesContainer]).then(
             (values) => {
-              console.log("Promise.all completed:");
-
               const sizesMap = values[0];
               const containersMap = values[1];
 
@@ -96,15 +83,20 @@ export const useGetVolumes = () => {
               for (const key in rows) {
                 const row = rows[key];
 
-                row.volumeContainers = containersMap[row.volumeName].Containers;
+                if (containersMap[row.volumeName] === undefined) {
+                  continue;
+                }
+
+                if (containersMap[row.volumeName].Containers?.length) {
+                  row.volumeContainers =
+                    containersMap[row.volumeName].Containers;
+                }
                 row.volumeSize = sizesMap[row.volumeName].Human;
                 row.volumeBytes = sizesMap[row.volumeName].Bytes;
 
                 updatedRows.push(row);
               }
 
-              console.log("updatedRows:");
-              console.log(updatedRows);
               setData(updatedRows);
               setIsVolumesSizeLoading(false);
             }

--- a/vm/internal/handler/containers.go
+++ b/vm/internal/handler/containers.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	"github.com/docker/docker/api/types/filters"
+	"net/http"
+	"sync"
+
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/labstack/echo"
+)
+
+func (h *Handler) VolumesContainer(ctx echo.Context) error {
+	ctxReq := ctx.Request().Context()
+	cli, err := h.DockerClient()
+	if err != nil {
+		return err
+	}
+
+	// TODO: receive volumes from body instead of recalculating it again?
+	v, err := cli.VolumeList(ctxReq, filters.NewArgs())
+	if err != nil {
+		return err
+	}
+
+	var res = VolumesResponse{
+		data: map[string]VolumeData{},
+	}
+
+	var wg sync.WaitGroup
+	for _, vol := range v.Volumes {
+		wg.Add(1)
+
+		go func(volumeName string) {
+			defer wg.Done()
+			containers := backend.GetContainersForVolume(ctxReq, cli, volumeName)
+			res.Lock()
+			defer res.Unlock()
+			entry, ok := res.data[volumeName]
+			if !ok {
+				res.data[volumeName] = VolumeData{
+					Containers: containers,
+				}
+				return
+			}
+			entry.Containers = containers
+			res.data[volumeName] = entry
+		}(vol.Name)
+	}
+
+	wg.Wait()
+
+	return ctx.JSON(http.StatusOK, res.data)
+}

--- a/vm/internal/handler/containers.go
+++ b/vm/internal/handler/containers.go
@@ -16,7 +16,6 @@ func (h *Handler) VolumesContainer(ctx echo.Context) error {
 		return err
 	}
 
-	// TODO: receive volumes from body instead of recalculating it again?
 	v, err := cli.VolumeList(ctxReq, filters.NewArgs())
 	if err != nil {
 		return err

--- a/vm/internal/handler/save_test.go
+++ b/vm/internal/handler/save_test.go
@@ -105,5 +105,5 @@ func TestSaveVolume(t *testing.T) {
 	require.Len(t, summary, 1)
 	require.Equal(t, imageID, summary[0].RepoTags[0])
 	t.Logf("Image size after saving volume into it: %d", summary[0].Size)
-	require.Regexp(t, "12449.*", strconv.FormatInt(summary[0].Size, 10))
+	require.Regexp(t, `124\d{4}`, strconv.FormatInt(summary[0].Size, 10), "the image size should be around 1.24MB")
 }

--- a/vm/internal/handler/sizes.go
+++ b/vm/internal/handler/sizes.go
@@ -1,0 +1,19 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/docker/volumes-backup-extension/internal/backend"
+	"github.com/labstack/echo"
+)
+
+func (h *Handler) VolumesSize(ctx echo.Context) error {
+	cli, err := h.DockerClient()
+	if err != nil {
+		return err
+	}
+
+	m := backend.GetVolumesSize(ctx.Request().Context(), cli, "*")
+
+	return ctx.JSON(http.StatusOK, m)
+}

--- a/vm/internal/handler/volumes.go
+++ b/vm/internal/handler/volumes.go
@@ -38,10 +38,7 @@ func (h *Handler) Volumes(ctx echo.Context) error {
 
 	for _, vol := range v.Volumes {
 		res.data[vol.Name] = VolumeData{
-			Driver:     vol.Driver,
-			Size:       -1,   // set to `-1` if the value is not available.
-			SizeHuman:  "-1", // set to `-1` if the value is not available.
-			Containers: nil,  // set to `nil` if the value is not available.
+			Driver: vol.Driver,
 		}
 	}
 

--- a/vm/internal/handler/volumes.go
+++ b/vm/internal/handler/volumes.go
@@ -38,69 +38,12 @@ func (h *Handler) Volumes(ctx echo.Context) error {
 
 	for _, vol := range v.Volumes {
 		res.data[vol.Name] = VolumeData{
-			Driver: vol.Driver,
-			//Size:       0,
-			//SizeHuman:  "",
-			//Containers: nil,
+			Driver:     vol.Driver,
+			Size:       -1,   // set to `-1` if the value is not available.
+			SizeHuman:  "-1", // set to `-1` if the value is not available.
+			Containers: nil,  // set to `nil` if the value is not available.
 		}
 	}
 
-	//var wg sync.WaitGroup
-	//// Calculating the volume size by spinning a container that execs "du " **per volume** is too time-consuming.
-	//// To reduce the time it takes, we get the volumes size by running only one container that execs "du"
-	//// into the /var/lib/docker/volumes inside the VM.
-	//volumesSize := backend.GetVolumesSize(ctx.Request().Context(), cli, "*")
-	//res.Lock()
-	//for k, v := range volumesSize {
-	//	entry, ok := res.data[k]
-	//	if !ok {
-	//		res.data[k] = VolumeData{
-	//			Size:      v.Bytes,
-	//			SizeHuman: v.Human,
-	//		}
-	//		continue
-	//	}
-	//	entry.Size = v.Bytes
-	//	entry.SizeHuman = v.Human
-	//	res.data[k] = entry
-	//}
-	//res.Unlock()
-	//
-	//for _, vol := range v.Volumes {
-	//	wg.Add(2)
-	//	go func(volumeName string) {
-	//		defer wg.Done()
-	//		driver := backend.GetVolumeDriver(context.Background(), cli, volumeName) // TODO: use request context
-	//		res.Lock()
-	//		defer res.Unlock()
-	//		entry, ok := res.data[volumeName]
-	//		if !ok {
-	//			res.data[volumeName] = VolumeData{
-	//				Driver: driver,
-	//			}
-	//			return
-	//		}
-	//		entry.Driver = driver
-	//		res.data[volumeName] = entry
-	//	}(vol.Name)
-	//
-	//	go func(volumeName string) {
-	//		defer wg.Done()
-	//		containers := backend.GetContainersForVolume(context.Background(), cli, volumeName) // TODO: use request context
-	//		res.Lock()
-	//		defer res.Unlock()
-	//		entry, ok := res.data[volumeName]
-	//		if !ok {
-	//			res.data[volumeName] = VolumeData{
-	//				Containers: containers,
-	//			}
-	//			return
-	//		}
-	//		entry.Containers = containers
-	//		res.data[volumeName] = entry
-	//	}(vol.Name)
-	//}
-	//
-	//wg.Wait()
 	return ctx.JSON(http.StatusOK, res.data)
 }

--- a/vm/internal/handler/volumes.go
+++ b/vm/internal/handler/volumes.go
@@ -1,12 +1,10 @@
 package handler
 
 import (
-	"context"
 	"net/http"
 	"sync"
 
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/volumes-backup-extension/internal/backend"
 	"github.com/docker/volumes-backup-extension/internal/log"
 	"github.com/labstack/echo"
 )
@@ -38,62 +36,71 @@ func (h *Handler) Volumes(ctx echo.Context) error {
 		data: map[string]VolumeData{},
 	}
 
-	var wg sync.WaitGroup
-	// Calculating the volume size by spinning a container that execs "du " **per volume** is too time-consuming.
-	// To reduce the time it takes, we get the volumes size by running only one container that execs "du"
-	// into the /var/lib/docker/volumes inside the VM.
-	volumesSize := backend.GetVolumesSize(ctx.Request().Context(), cli, "*")
-	res.Lock()
-	for k, v := range volumesSize {
-		entry, ok := res.data[k]
-		if !ok {
-			res.data[k] = VolumeData{
-				Size:      v.Bytes,
-				SizeHuman: v.Human,
-			}
-			continue
-		}
-		entry.Size = v.Bytes
-		entry.SizeHuman = v.Human
-		res.data[k] = entry
-	}
-	res.Unlock()
-
 	for _, vol := range v.Volumes {
-		wg.Add(2)
-		go func(volumeName string) {
-			defer wg.Done()
-			driver := backend.GetVolumeDriver(context.Background(), cli, volumeName) // TODO: use request context
-			res.Lock()
-			defer res.Unlock()
-			entry, ok := res.data[volumeName]
-			if !ok {
-				res.data[volumeName] = VolumeData{
-					Driver: driver,
-				}
-				return
-			}
-			entry.Driver = driver
-			res.data[volumeName] = entry
-		}(vol.Name)
-
-		go func(volumeName string) {
-			defer wg.Done()
-			containers := backend.GetContainersForVolume(context.Background(), cli, volumeName) // TODO: use request context
-			res.Lock()
-			defer res.Unlock()
-			entry, ok := res.data[volumeName]
-			if !ok {
-				res.data[volumeName] = VolumeData{
-					Containers: containers,
-				}
-				return
-			}
-			entry.Containers = containers
-			res.data[volumeName] = entry
-		}(vol.Name)
+		res.data[vol.Name] = VolumeData{
+			Driver: vol.Driver,
+			//Size:       0,
+			//SizeHuman:  "",
+			//Containers: nil,
+		}
 	}
 
-	wg.Wait()
+	//var wg sync.WaitGroup
+	//// Calculating the volume size by spinning a container that execs "du " **per volume** is too time-consuming.
+	//// To reduce the time it takes, we get the volumes size by running only one container that execs "du"
+	//// into the /var/lib/docker/volumes inside the VM.
+	//volumesSize := backend.GetVolumesSize(ctx.Request().Context(), cli, "*")
+	//res.Lock()
+	//for k, v := range volumesSize {
+	//	entry, ok := res.data[k]
+	//	if !ok {
+	//		res.data[k] = VolumeData{
+	//			Size:      v.Bytes,
+	//			SizeHuman: v.Human,
+	//		}
+	//		continue
+	//	}
+	//	entry.Size = v.Bytes
+	//	entry.SizeHuman = v.Human
+	//	res.data[k] = entry
+	//}
+	//res.Unlock()
+	//
+	//for _, vol := range v.Volumes {
+	//	wg.Add(2)
+	//	go func(volumeName string) {
+	//		defer wg.Done()
+	//		driver := backend.GetVolumeDriver(context.Background(), cli, volumeName) // TODO: use request context
+	//		res.Lock()
+	//		defer res.Unlock()
+	//		entry, ok := res.data[volumeName]
+	//		if !ok {
+	//			res.data[volumeName] = VolumeData{
+	//				Driver: driver,
+	//			}
+	//			return
+	//		}
+	//		entry.Driver = driver
+	//		res.data[volumeName] = entry
+	//	}(vol.Name)
+	//
+	//	go func(volumeName string) {
+	//		defer wg.Done()
+	//		containers := backend.GetContainersForVolume(context.Background(), cli, volumeName) // TODO: use request context
+	//		res.Lock()
+	//		defer res.Unlock()
+	//		entry, ok := res.data[volumeName]
+	//		if !ok {
+	//			res.data[volumeName] = VolumeData{
+	//				Containers: containers,
+	//			}
+	//			return
+	//		}
+	//		entry.Containers = containers
+	//		res.data[volumeName] = entry
+	//	}(vol.Name)
+	//}
+	//
+	//wg.Wait()
 	return ctx.JSON(http.StatusOK, res.data)
 }

--- a/vm/internal/handler/volumes_test.go
+++ b/vm/internal/handler/volumes_test.go
@@ -50,8 +50,8 @@ func TestVolumes(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, m, volume)
 	require.Equal(t, "local", m[volume].Driver)
-	require.Equal(t, int64(-1), m[volume].Size)
-	require.Equal(t, "-1", m[volume].SizeHuman)
+	require.Equal(t, int64(0), m[volume].Size)
+	require.Equal(t, "", m[volume].SizeHuman)
 	require.Len(t, m[volume].Containers, 0)
 }
 

--- a/vm/internal/handler/volumes_test.go
+++ b/vm/internal/handler/volumes_test.go
@@ -50,8 +50,8 @@ func TestVolumes(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, m, volume)
 	require.Equal(t, "local", m[volume].Driver)
-	require.Equal(t, int64(0), m[volume].Size)
-	require.Equal(t, "0 B", m[volume].SizeHuman)
+	require.Equal(t, int64(-1), m[volume].Size)
+	require.Equal(t, "-1", m[volume].SizeHuman)
 	require.Len(t, m[volume].Containers, 0)
 }
 

--- a/vm/main.go
+++ b/vm/main.go
@@ -61,6 +61,8 @@ func main() {
 
 	router.GET("/progress", h.ActionsInProgress)
 	router.GET("/volumes", h.Volumes)
+	router.GET("/volumes/size", h.VolumesSize)
+	router.GET("/volumes/container", h.VolumesContainer)
 	router.GET("/volumes/:volume/size", h.VolumeSize)
 	router.POST("/volumes/:volume/clone", h.CloneVolume)
 	router.POST("/volumes/:volume/delete", h.DeleteVolume)


### PR DESCRIPTION
Currently, the reason why the list of volumes takes some time to load is that calculating the size of each is an expensive operation (the bigger the volumes, the longer it'll take) _and_ it retrieves the list of containers for every volume.

Instead, we could:

1. Retrieve the list of volumes (without calculating their size). This should be much faster.
2. Once the list is loaded, calculate the volume size _and_ the containers attached *in the background*.



https://user-images.githubusercontent.com/15997951/189663566-c250a836-cc0e-4c96-ae22-c53c1b600974.mov

