### PR TITLE
Avoid duplication of image labels

### DIFF
--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -81,14 +81,6 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=semver,pattern={{version}}
-          # The action will generate its own OCI labels that are not suitable for the Marketplace.
-          # We have to override them with the same values as the ones defined in the Dockerfile.
-          # https://github.com/docker/metadata-action#overwrite-labels
-          labels: |
-            org.opencontainers.image.title=Volumes Backup & Share
-            org.opencontainers.image.description=Back up, clone, restore, and share Docker volumes effortlessly.
-            org.opencontainers.image.vendor=Docker Inc.
-            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha || github.event.after || github.event.release.tag_name }}
 
       - name: Docker Build and Push to Docker Hub
         if: ${{ !github.event.pull_request.head.repo.fork }}
@@ -96,7 +88,9 @@ jobs:
         with:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha || github.event.after || github.event.release.tag_name }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Replaces #76 , but don't loose buildx cache for every build

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>