### PR TITLE
Fix row index

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -404,8 +404,10 @@ export function App() {
   ) => {
     if (actionSuccessfullyCompleted) {
       const rowsCopy = rows.slice();
+      const highestId = rows.slice(-1)[0].id;
+      const nextId = highestId + 1;
       rowsCopy.push({
-        id: rows.length,
+        id: nextId,
         volumeName: clonedVolumeName,
         volumeDriver: "local",
       });


### PR DESCRIPTION
@benja-M-1 reported the following issue:

> I import a volume from a fake repo: aaa/aaa:aaa
> I delete the created volume
> I clone a volume
> -> the cloned volume name changes, I have two volumes with the same name that include the -cloned suffix

https://user-images.githubusercontent.com/15997951/192000660-7512c5cd-b953-40b5-a4f9-9efdf6848a4b.mov

The row index was not being calculated correctly, causing two rows to share the same "unique" id:

![image](https://user-images.githubusercontent.com/15997951/192000915-87eaead8-254d-4a85-a004-af5eb9817aa5.png)


