### PR TITLE
Don't fail the build when MUI key is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE?=docker/volumes-backup-extension
 TAG?=latest
 BUILDER=buildx-multi-arch
-REACT_APP_MUI_LICENSE_KEY?=UNKNOWN_KEY
+export REACT_APP_MUI_LICENSE_KEY?=UNKNOWN_KEY
 
 export BUGSNAG_API_KEY?=
 export BUGSNAG_RELEASE_STAGE?=local


### PR DESCRIPTION
Given the `REACT_APP_MUI_LICENSE_KEY` is not shared in the repo, we should not make the `docker build` operation fail if it's not present:

## Before

```
make build-extension
docker buildx build \
		--secret id=BUGSNAG_API_KEY \
		--secret id=REACT_APP_MUI_LICENSE_KEY \
		--build-arg BUGSNAG_RELEASE_STAGE=local \
		--build-arg BUGSNAG_APP_VERSION=latest \
		--load \
		--tag=docker/volumes-backup-extension:latest \
		.
ERROR: failed to stat REACT_APP_MUI_LICENSE_KEY: stat REACT_APP_MUI_LICENSE_KEY: no such file or directory
make: *** [build-extension] Error 1
```

