### PR TITLE
Remove custom styles from notifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,12 +92,7 @@ LABEL org.opencontainers.image.title="Volumes Backup & Share" \
     ]" \
     com.docker.desktop.extension.icon="https://raw.githubusercontent.com/docker/volumes-backup-extension/main/icon.svg" \
     com.docker.extension.changelog="<ul>\
-    <li>Improved volume list performance.</li> \
-    <li>Added support to import backups from any .tar.gz.</li> \
-    <li>Changed the clone operation to copy the volume labels as well.</li> \
-    <li>Fixed a bug where the clone operation will not validate whether the destination volume already existed.</li> \
-    <li>Added error tracking to detect issues before users report them.</li> \
-    <li>Fixed new vulnerabilities detected in the Dockerfile.</li> \
+    <li>Fixed an issue with notifications and the new Design System.</li> \
     </ul>" \
     com.docker.extension.categories="volumes"
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -439,6 +439,7 @@ export function App() {
       return;
     }
     calculateVolumeSize(recalculateVolumeSize);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recalculateVolumeSize]);
 
   const handleTransferDialogClose = () => {

--- a/ui/src/NotificationContext.tsx
+++ b/ui/src/NotificationContext.tsx
@@ -59,6 +59,7 @@ export const NotificationProvider: FC = ({ children }) => {
         {actions.map((action) => (
           <Button
             key={action.name}
+            variant="text"
             onClick={() => {
               if (action.onClick) action.onClick();
               setOpen(false);
@@ -85,24 +86,6 @@ export const NotificationProvider: FC = ({ children }) => {
             message={values.message}
             action={buildActions(values.actions || [DEFAULT_ACTION])}
             sx={{
-              "& .MuiButton-root": {
-                color: useLightTheme
-                  ? (theme) => theme.palette.docker.blue[500]
-                  : "white",
-                "&:hover": {
-                  backgroundColor: (theme) => {
-                    if (values.type === "error") {
-                      return useLightTheme
-                        ? theme.palette.docker.red[200]
-                        : theme.palette.docker.red[100];
-                    }
-
-                    return useLightTheme
-                      ? "white"
-                      : theme.palette.docker.grey[200];
-                  },
-                },
-              },
               backgroundColor: (theme) => {
                 if (values.type === "error") {
                   return useLightTheme
@@ -110,7 +93,9 @@ export const NotificationProvider: FC = ({ children }) => {
                     : theme.palette.docker.red[200];
                 }
 
-                return useLightTheme ? "white" : theme.palette.docker.grey[200];
+                return useLightTheme
+                  ? theme.palette.common.white
+                  : theme.palette.docker.grey[200];
               },
               color: (theme) => theme.palette.text.primary,
               borderRadius: "4px !important",

--- a/vm/internal/handler/save_test.go
+++ b/vm/internal/handler/save_test.go
@@ -105,5 +105,5 @@ func TestSaveVolume(t *testing.T) {
 	require.Len(t, summary, 1)
 	require.Equal(t, imageID, summary[0].RepoTags[0])
 	t.Logf("Image size after saving volume into it: %d", summary[0].Size)
-	require.Regexp(t, `124\d{4}`, strconv.FormatInt(summary[0].Size, 10), "the image size should be around 1.24MB")
+	require.Regexp(t, `\d{7}`, strconv.FormatInt(summary[0].Size, 10), "the image size should be between 1 and 10 MB")
 }


### PR DESCRIPTION
## What does this PR do?
- Changes the button to a text variant and removes custom styling. Now it matches the DS.

### Success / info
| Dark | Light |
| - | - |
| ![image](https://user-images.githubusercontent.com/8645841/211590623-cbf3e3ca-44d5-49fa-9b06-98501e064fce.png) |  ![image](https://user-images.githubusercontent.com/8645841/211590552-864394b7-3086-408c-9fcb-5a636e3e95b9.png) |

### Error
| Dark | Light |
| - | - |
| ![image](https://user-images.githubusercontent.com/8645841/211589699-815c1aa6-1c0c-476b-b012-3b1cc04542f2.png) | ![image](https://user-images.githubusercontent.com/8645841/211589784-b36d8010-4d96-4f5c-b6a5-2795410c5ffd.png) |
