### PR TITLE
HP-233 Consolidate Docker Hub bots

### DIFF
--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -65,8 +65,8 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: dockerpublicbot
+          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
 
       - name: Docker Metadata for Final Image Build
         id: docker_meta


### PR DESCRIPTION
# Description

This PR is replacing the usage of the current bot user by `dockerpublicbot`. The new secret `DOCKERPUBLICBOT_WRITE_PAT` is set at the GitHub org level.

The goal is to consolidate our Docker Hub bot accounts.

# References

- **JIRA** - https://docker.atlassian.net/browse/HP-233