### PR TITLE
Fix MUI license injection

### DIFF
--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -113,8 +113,8 @@ jobs:
         with:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
-          #sbom: ${{ github.event_name != 'pull_request' }}
-          #provenance: ${{ github.event_name != 'pull_request' }}
+          sbom: ${{ github.event_name != 'pull_request' }}
+          provenance: ${{ github.event_name != 'pull_request' }}
           labels: |
             org.opencontainers.image.revision=${{ github.event.pull_request.head.sha || github.event.after || github.event.release.tag_name }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}

--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Docker Build and Push to Docker Hub
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -109,12 +109,12 @@ jobs:
 
       - name: Docker Build and Push to Docker Hub
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v2
         with:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
-          sbom: ${{ github.event_name != 'pull_request' }}
-          provenance: ${{ github.event_name != 'pull_request' }}
+          #sbom: ${{ github.event_name != 'pull_request' }}
+          #provenance: ${{ github.event_name != 'pull_request' }}
           labels: |
             org.opencontainers.image.revision=${{ github.event.pull_request.head.sha || github.event.after || github.event.release.tag_name }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}

--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Docker Build and Push to Docker Hub
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -125,8 +125,8 @@ jobs:
             BUGSNAG_RELEASE_STAGE=production
             BUGSNAG_APP_VERSION=${{ github.event.release.tag_name }}
           secrets: |
-            BUGSNAG_API_KEY=${{ secrets.BUGSNAG_API_KEY }}
-            REACT_APP_MUI_LICENSE_KEY=${{ secrets.REACT_APP_MUI_LICENSE_KEY }}
+            "BUGSNAG_API_KEY=${{ secrets.BUGSNAG_API_KEY }}"
+            "REACT_APP_MUI_LICENSE_KEY=${{ secrets.REACT_APP_MUI_LICENSE_KEY }}"
 
         # If PR, put image tags in the PR comments
         # from https://github.com/marketplace/actions/create-or-update-comment

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,11 @@ RUN --mount=type=cache,target=/usr/src/app/.npm \
     npm ci
 # install
 COPY ui /ui
-RUN --mount=type=secret,id=BUGSNAG_API_KEY \
+RUN --mount=type=secret,id=BUGSNAG_API_KEY,target=/run/secrets/BUGSNAG_API_KEY \
+    --mount=type=secret,id=REACT_APP_MUI_LICENSE_KEY,target=/run/secrets/REACT_APP_MUI_LICENSE_KEY \
     REACT_APP_BUGSNAG_API_KEY=$(cat /run/secrets/BUGSNAG_API_KEY) \
-    npm run build
-RUN --mount=type=secret,id=REACT_APP_MUI_LICENSE_KEY \
     REACT_APP_MUI_LICENSE_KEY=$(cat /run/secrets/REACT_APP_MUI_LICENSE_KEY) \
-    yarn build
+    npm run build
 
 FROM alpine:3.16@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad as base
 ARG CLI_VERSION=20.10.17


### PR DESCRIPTION
Version 1.1.5 (which is the latest at the time of writing) does not contain the MUI license, and thus, the watermark appears.I am not able to explain why, but if you install the version from this PR, the MUI watermark is not present.

<img width="1138" alt="Screenshot 2024-04-19 at 09 27 45" src="https://github.com/docker/volumes-backup-extension/assets/212269/26793b55-2577-4a3a-9435-ff80ed63426f">

What did I do?
- changed the license key in the secrets used by the GHA
- added commas on each secret as specified on https://docs.docker.com/build/ci/github-actions/secrets/
- used a single RUN instruction to mount the Bugsnag key and the MUI license key

However, I am not 100% confident those changes are what fixed the issue. I rather suspect something in the actions we use to build and push images.

Anyway, the built image of this PR works so I'd be keen on releasing a new version once this PR got merged.