### PR TITLE
Fix MUI license issue

### DIFF
--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -124,6 +124,7 @@ jobs:
           build-args: |
             BUGSNAG_RELEASE_STAGE=production
             BUGSNAG_APP_VERSION=${{ github.event.release.tag_name }}
+            VALID_SECRET_CACHE=1
           secrets: |
             "BUGSNAG_API_KEY=${{ secrets.BUGSNAG_API_KEY }}"
             "REACT_APP_MUI_LICENSE_KEY=${{ secrets.REACT_APP_MUI_LICENSE_KEY }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN --mount=type=cache,target=/usr/src/app/.npm \
     npm ci
 # install
 COPY ui /ui
+# avoid reusing cached layers from another build without secrets provided, cf https://docs.docker.com/build/cache/invalidation/#build-secrets
+ARG VALID_SECRET_CACHE 
 RUN --mount=type=secret,id=BUGSNAG_API_KEY,target=/run/secrets/BUGSNAG_API_KEY \
     --mount=type=secret,id=REACT_APP_MUI_LICENSE_KEY,target=/run/secrets/REACT_APP_MUI_LICENSE_KEY \
     REACT_APP_BUGSNAG_API_KEY=$(cat /run/secrets/BUGSNAG_API_KEY) \
@@ -92,7 +94,7 @@ LABEL org.opencontainers.image.title="Volumes Backup & Share" \
     ]" \
     com.docker.desktop.extension.icon="https://raw.githubusercontent.com/docker/volumes-backup-extension/main/icon.svg" \
     com.docker.extension.changelog="<ul>\
-    <li>Fixed current image vulnerabilities (CVEs) using Docker Scout.</li> \
+    <li>Fix MUI missing license.</li> \
     </ul>" \
     com.docker.extension.categories="volumes"
 
@@ -108,6 +110,7 @@ COPY --from=docker-credentials-client-builder output/dist ./host
 
 RUN mkdir -p /vackup
 
+ARG VALID_SECRET_CACHE 
 RUN --mount=type=secret,id=BUGSNAG_API_KEY \
     BUGSNAG_API_KEY=$(cat /run/secrets/BUGSNAG_API_KEY); \
     echo "$BUGSNAG_API_KEY" > /tmp/bugsnag-api-key.txt


### PR DESCRIPTION
Fix docker build caching issue with secrets. This is causing the extension to display a "missing license" watermark on the UI table

Building a first time without secrets (to export for scout) introduced some cached layers that are wrongly reused when building with secrets. 
See [known issue and fix](https://docs.docker.com/build/cache/invalidation/#build-secrets)

We can see in this [build](https://github.com/docker/volumes-backup-extension/actions/runs/8845697850/job/24290166420#step:10:260) that the npm build using the secret is not using cache, that is already build in step "Build and export"