### PR TITLE
Since the extension backend is executing inside the VM, no need to go through the socket on the host, use the engine socket directly

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,4 +6,4 @@ services:
       - DAC_OVERRIDE
       - FOWNER
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock.raw:/var/run/docker.sock


### PR DESCRIPTION
Tested export of local image, and export to registry / import from registry