### PR TITLE
Updates the deprecation banner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ LABEL org.opencontainers.image.title="Volumes Backup & Share" \
     {\"alt\": \"Clone volume dialog\", \"url\": \"https://raw.githubusercontent.com/docker/volumes-backup-extension/main/docs/images/5-clone.png\"}, \
     {\"alt\": \"Delete volume dialog\", \"url\": \"https://raw.githubusercontent.com/docker/volumes-backup-extension/main/docs/images/6-delete.png\"} \
     ]" \
-    com.docker.extension.detailed-description="<p><strong>The functionality in this extension is now available as a Beta feature in the Volumes tab in Docker Desktop versions 4.29.0 and later. This extension will be deprecated once the features are out of Beta.</strong> <a href='https://docs.docker.com/desktop/use-desktop/volumes/'>Learn more</a></p> \
+    com.docker.extension.detailed-description="<p><strong>The functionality in this extension has been available in the Volumes tab of Docker Desktop in versions 4.29 and later. This extension will be deprecated and removed from the marketplace effective September 30, 2024.</strong> <a href='https://docs.docker.com/desktop/use-desktop/volumes/'>Learn more</a></p> \
     <p>With Volumes Backup & Share you can easily create copies of your volumes and also share them with others through SSH or pushing them to a registry.</p> \
     <h2 id="-features">✨ What can you do with this extension?</h2> \
     <ul> \

--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@
 [![Build, Scan and Push](https://github.com/docker/volumes-backup-extension/actions/workflows/build-scan-push.yaml/badge.svg)](https://github.com/docker/volumes-backup-extension/actions/workflows/build-scan-push.yaml)
 [![Lint Dockerfile](https://github.com/docker/volumes-backup-extension/actions/workflows/hadolint.yaml/badge.svg)](https://github.com/docker/volumes-backup-extension/actions/workflows/hadolint.yaml)
 
-
 > [!IMPORTANT]
-> The functionality in this extension is now available as a Beta feature in the Volumes tab of Docker Desktop in versions 4.29.0 and above. This extension will be deprecated once the features are out of Beta. [Learn more](https://docs.docker.com/desktop/use-desktop/volumes/)
-
+> The functionality in this extension has been available in the Volumes tab of Docker Desktop in versions 4.29 and later. This extension will be deprecated and removed from the marketplace effective September 30, 2024. [Learn more](https://docs.docker.com/desktop/use-desktop/volumes/)
 
 ![Extension Screenshot](./docs/images/1-table.png)
 
@@ -32,6 +30,7 @@
 
 The recommended way to install the extension is from the Marketplace in Docker Desktop.
 You could also install it with the Docker Extensions CLI, targeting either a published released (e.g. `1.0.0`) or branch (e.g. `main`):
+
 ```bash
   docker extension install docker/volumes-backup-extension:main
 ```

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -42,9 +42,10 @@ export const Header = () => (
       })}
     >
       <Typography variant="body1" sx={{ p: 2 }}>
-        The functionality in this extension is now available as a Beta feature
-        in the Volumes tab in Docker Desktop versions 4.29.0 and later. This
-        extension will be deprecated once the features are out of Beta.{" "}
+        The functionality in this extension has been available in the Volumes
+        tab of Docker Desktop in versions 4.29 and later.This extension will be
+        deprecated and removed from the marketplace effective September 30,
+        2024.{" "}
         <Link
           href="#"
           onClick={() => {


### PR DESCRIPTION
## This Extension Is Deprecated
Updating the extension deprecation messaging, the extension will be available on the marketplace until Sept. 30th. You can now export volumes without the need of an extension in the volumes tab of Docker Desktop above version `4.29`. [Learn more](https://docs.docker.com/desktop/use-desktop/volumes/)